### PR TITLE
Add example scripts and README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ df_novo = novo_encoder.transform(novo_df)
 
 ---
 
+## 🔄 Fluxo de Processamento
+
+```mermaid
+flowchart LR
+    A[Dados brutos + target] --> B[EncodingManager]
+    B --> |fit| C[Encoder interno]
+    C --> D[Mapeamentos]
+    B --> |transform| E[DataFrame codificado]
+    E --> F[Modelo/Pipeline]
+```
+
+---
+
 ## 📒 API Reference
 
 | Método                  | Descrição                                                           |
@@ -75,6 +88,22 @@ encoder.export_log("woe_log.json")
 # Reutilizar depois
 encoder_reusado = WOEGuard.load_from_json("woe_log.json")
 encoder_reusado.transform(novo_dataframe)
+```
+
+---
+
+## 📚 Exemplos de Uso
+
+Scripts completos estão disponíveis em [`src/examples`](src/examples):
+
+- `simple_usage.py` – demonstra o ajuste e aplicação do `WOEGuard`.
+- `pipeline_example.py` – constrói um pipeline de treinamento utilizando o `EncodingManager`.
+
+Execute-os com:
+
+```bash
+python src/examples/simple_usage.py
+python src/examples/pipeline_example.py
 ```
 
 ---

--- a/src/examples/pipeline_example.py
+++ b/src/examples/pipeline_example.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import pandas as pd
+
+# permite importar modulos da pasta pai
+sys.path.append(os.path.abspath(".."))
+from pipelines.training import build_pipeline
+
+DATA_PATH = os.path.join("..", "data", "case_data_science_credit.csv")
+df = pd.read_csv(DATA_PATH, sep=";")
+
+categorical_cols = [
+    "qtd_restritivos",
+    "verificacao_fonte_de_renda",
+    "qtd_atrasos_ultimos_2a",
+    "qtd_consultas_ultimos_6m",
+]
+
+y = df["target"]
+X = df.drop(columns=["target"])
+
+pipeline = build_pipeline(categorical_cols)
+pipeline.fit(X, y)
+
+print("Pipeline treinado com sucesso")

--- a/src/examples/simple_usage.py
+++ b/src/examples/simple_usage.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import pandas as pd
+
+# permite importar pacotes do diret\u00f3rio pai
+sys.path.append(os.path.abspath(".."))
+from woe_guard import WOEGuard
+
+# carrega dataset de exemplo
+DATA_PATH = os.path.join("..", "data", "case_data_science_credit.csv")
+df = pd.read_csv(DATA_PATH, sep=";")
+
+categorical_cols = [
+    "qtd_restritivos",
+    "verificacao_fonte_de_renda",
+    "qtd_atrasos_ultimos_2a",
+    "qtd_consultas_ultimos_6m",
+]
+
+# instancia e aplica o WOEGuard
+encoder = WOEGuard(categorical_cols=categorical_cols, drop_original=True)
+encoded = encoder.fit_transform(df[categorical_cols], df["target"])
+print(encoded.head())


### PR DESCRIPTION
## Summary
- add simple and pipeline examples using the available credit dataset
- document usage of examples and add flowchart in README

## Testing
- `pip install pandas scikit-learn openpyxl`
- `pip install matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bb0e069b08321a02bd42b9598bf95